### PR TITLE
cmake: fix installation of fbs files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,7 +177,7 @@ configure_file(
 install(  # install flatbuf proto defs
   DIRECTORY ${LIBSIGMF_GEN_HEADERS}/
   DESTINATION include/sigmf/fbs
-  FILES_MATCHING PATTERN "*.fbs)")
+  FILES_MATCHING PATTERN "*.fbs")
 install(  # install generated headers
   DIRECTORY ${LIBSIGMF_GEN_HEADERS}/
   DESTINATION include/sigmf


### PR DESCRIPTION
There's a typo in `CMakeLists.txt` that causes the fbs files to not be installed.