### PR TITLE
Replace core:label by core:description

### DIFF
--- a/sigmf_protocols/sigmf_core.fbs
+++ b/sigmf_protocols/sigmf_core.fbs
@@ -31,7 +31,7 @@ table Annotation {
     freq_upper_edge:float64;
     sample_start:uint64;
     sample_count:uint64;
-    description:string;
+    label:string;
     generator:string;
     comment:string;
 }


### PR DESCRIPTION
As per the SigMF specification, annotations have an optional `core:label` attribute, no `core:description`.

Resolves #11