### PR TITLE
Mait/system wide fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ set(libsigmf_deps "")
 
 # flatbuffers
 if (${USE_SYSTEM_FLATBUFFERS})
-  find_package(Flatbuffers REQUIRED)
+  find_package(FlatBuffers REQUIRED NAMES FlatBuffers Flatbuffers)
 endif (${USE_SYSTEM_FLATBUFFERS})
 
 if (NOT ${USE_SYSTEM_FLATBUFFERS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,7 +146,7 @@ set(LIBSIGMF_PREGEN_HEADERS "${CMAKE_CURRENT_SOURCE_DIR}/sigmf_protocols")
 ########################################################################
 add_library(libsigmf INTERFACE)
 target_include_directories(libsigmf INTERFACE
-  $<INSTALL_INTERFACE:include>
+  $<INSTALL_INTERFACE:include/sigmf>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
   $<INSTALL_INTERFACE:include/sigmf/fbs>
   $<BUILD_INTERFACE:${LIBSIGMF_PREGEN_HEADERS}>

--- a/cmake/config.cmake.in
+++ b/cmake/config.cmake.in
@@ -13,6 +13,6 @@ if(NOT TARGET @PROJECT_NAME@::@LIBSIGMF_TARGET_NAME@)
   include(CMakeFindDependencyMacro)
 
   find_dependency(nlohmann_json REQUIRED)
-  find_dependency(Flatbuffers REQUIRED)
+  find_dependency(FlatBuffers REQUIRED NAMES FlatBuffers Flatbuffers)
   include("${CMAKE_CURRENT_LIST_DIR}/@LIBSIGMF_TARGETS_EXPORT_NAME@.cmake")
 endif()


### PR DESCRIPTION
Patches used in my initial Debian packaging for system-wide use of libsigmf.

The reliable finding patch handles variations in CMake interface file naming in recent
flatbuffers. 2.0.8, 22.12.06. This is needed to find the FlatBuffersConfig.cmake in Debian's
flatbuffers 2.0.8+dfsg1-2.

The fix cmake interface patch is needed so that another application can just
#include <sigmf.h>
as suggested in the README.md, even though the system-wide config location is
/usr/include/sigmf/sigmf.h

For your consideration, so that a libsigmf 1.0.3 release might work as expected system-wide.